### PR TITLE
Fix multiqc wrapper + slurm issue

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -21,7 +21,7 @@ report: "report/workflow.rst"
 if config['DATA'] == "Single" or config['DATA'] == 'single':
     rule all:
         input:
-            "../results/qc/multiqc.html",
+            "../results/qc/multiqc_report.html",
             expand("../results/mapped/{sample}_recalibrated.bam", sample = SAMPLES),
             expand("../results/called/{sample}_raw_snps_indels.vcf", sample = SAMPLES),
             
@@ -29,7 +29,7 @@ if config['DATA'] == "Single" or config['DATA'] == 'single':
 if config['DATA'] == "Cohort" or config['DATA'] == 'cohort':
     rule all:
         input:
-            "../results/qc/multiqc.html",
+            "../results/qc/multiqc_report.html",
             expand("../results/mapped/{sample}_recalibrated.bam", sample = SAMPLES),
             expand("../results/called/{family}_raw_snps_indels_g.vcf", family = FAMILIES)
 

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - bioconda::multiqc =1.8

--- a/workflow/rules/multiqc.smk
+++ b/workflow/rules/multiqc.smk
@@ -2,12 +2,12 @@ rule multiqc:
     input:
         expand("../results/qc/fastqc/{sample}_fastqc.zip", sample = SAMPLES)
     output:
-        report("../results/qc/multiqc.html", caption = "../report/quality_checks.rst", category = "Quality checks")
-    params:
-        ""
+        report("../results/qc/multiqc_report.html", caption = "../report/quality_checks.rst", category = "Quality checks")
+    conda:
+        "../envs/multiqc.yaml"
     log:
         "logs/multiqc/multiqc.log"
     message:
         "Compiling a HTML report for quality control checks on raw sequence data"
-    wrapper:
-        "0.64.0/bio/multiqc"
+    shell:
+        "multiqc {input} -o ../results/qc/ &> {log}"


### PR DESCRIPTION
Since it's not necessary to use the multiqc wrapper, I simply reverted back to not using a snakemake wrapper for this rule to avoid the issues associated with using this multiqc wrapper when deployed to slurm