### PR TITLE
Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,10 @@ Specify whether the pipeline should be GPU accelerated where possible (either 'Y
 GPU_ACCELERATED: "No"
 ```
 
-Set the the working directories to the reference human genome file (b37 or hg38) and it's associated dictionary file (.dict). For example:
+Set the the working directories to the reference human genome file (b37 or hg38). For example:
 
 ```yaml
 REFGENOME: "/home/lkemp/publicData/b37/human_g1k_v37_decoy.fasta"
-DICT: "/home/lkemp/publicData/b37/human_g1k_v37_decoy.dict"
 ```
 
 Set the the working directory to your dbSNP database file (b37 or hg38). For example:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ Configure `account:` and `partition:` in the default section of 'cluster.json' i
     "__default__" :
     {
         "account" : "lkemp",
-        "partition" : "prod"
+        "partition" : "prod",
+        "output" : "logs/slurm-%j_{rule}_{wildcards.sample}.out"
     }
 }
 ```
@@ -287,7 +288,8 @@ snakemake \
 --configfile ../config/config.yaml \
 --cluster-config ../config/cluster.json \
 --cluster "sbatch -A {cluster.account} \
--p {cluster.partition}"
+-p {cluster.partition} \
+-o {cluster.output}"
 ```
 
 Full run (run_hpc.sh):
@@ -302,7 +304,8 @@ snakemake \
 --configfile ../config/config.yaml \
 --cluster-config ../config/cluster.json \
 --cluster "sbatch -A {cluster.account} \
--p {cluster.partition}"
+-p {cluster.partition} \
+-o {cluster.output}"
 ```
 
 ### 7. Create and activate a conda environment with python and snakemake installed

--- a/config/cluster.json
+++ b/config/cluster.json
@@ -2,6 +2,7 @@
     "__default__" :
     {
         "account" : "",
-        "partition" : ""
+        "partition" : "",
+        "output" : "logs/slurm-%j_{rule}_{wildcards.sample}.out"
     }
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,9 +8,8 @@ DATA: ""
 # Should the pipeline be GPU accelerated where possible? (either 'Yes' or 'No')
 GPU_ACCELERATED: ""
 
-# File paths to the reference genome (.fasta) and it's associated dictionary file (.dict)
+# File path to the reference genome (.fasta)
 REFGENOME: ""
-DICT: ""
 
 # File path to dbSNP database
 dbSNP: ""

--- a/workflow/dryrun_hpc.sh
+++ b/workflow/dryrun_hpc.sh
@@ -10,4 +10,5 @@ snakemake \
 --configfile ../config/config.yaml \
 --cluster-config ../config/cluster.json \
 --cluster "sbatch -A {cluster.account} \
--p {cluster.partition}"
+-p {cluster.partition} \
+-o {cluster.output}"

--- a/workflow/logs/README.md
+++ b/workflow/logs/README.md
@@ -1,0 +1,1 @@
+Snakemake and slurm log files will reside here

--- a/workflow/rules/gatk_ApplyBQSR.smk
+++ b/workflow/rules/gatk_ApplyBQSR.smk
@@ -1,13 +1,14 @@
 rule gatk_ApplyBQSR:
     input:
         bam = "../results/mapped/{sample}_sorted_mkdups.bam",
-        recal_table = "../results/mapped/{sample}_recalibration_report.grp",
-        ref = expand("{ref}", ref = config['REFGENOME']),
-        dict = expand("{dict}", dict = config['DICT'])
+        recal = "../results/mapped/{sample}_recalibration_report.grp",
+        refgenome = expand("{refgenome}", refgenome = config['REFGENOME'])
     output:
         bam = protected("../results/mapped/{sample}_recalibrated.bam")
     params:
-        java_opts = expand('"-Xmx{java_opts}"', java_opts = config['MAXMEMORY']),
+        maxmemory = expand('"-Xmx{maxmemory}"', maxmemory = config['MAXMEMORY']),
+        padding = expand("{padding}", padding = config['WES']['PADDING']),
+        intervals = expand("{intervals}", intervals = config['WES']['INTERVALS'])
     log:
         "logs/gatk_ApplyBQSR/{sample}.log"
     benchmark:
@@ -16,5 +17,5 @@ rule gatk_ApplyBQSR:
         "../envs/gatk4.yaml"
     message:
         "Applying base quality score recalibration and producing a recalibrated BAM file for {input.bam}"
-    wrapper:
-        "0.64.0/bio/gatk/applybqsr"
+    shell:
+        "gatk ApplyBQSR --java-options {params.maxmemory} -I {input.bam} -bqsr {input.recal} -R {input.refgenome} -O {output} {params.padding} {params.intervals}"

--- a/workflow/rules/trim_galore_pe.smk
+++ b/workflow/rules/trim_galore_pe.smk
@@ -11,7 +11,7 @@ rule trim_galore_pe:
         threads = expand("{threads}", threads = config['THREADS']),
         other = "-q 20 --paired"
     log:
-        "logs/trim_galore/{sample}.log"
+        "logs/trim_galore_pe/{sample}.log"
     benchmark:
         "benchmarks/trim_galore_pe/{sample}.tsv"
     conda:

--- a/workflow/run_hpc.sh
+++ b/workflow/run_hpc.sh
@@ -9,4 +9,5 @@ snakemake \
 --configfile ../config/config.yaml \
 --cluster-config ../config/cluster.json \
 --cluster "sbatch -A {cluster.account} \
--p {cluster.partition}"
+-p {cluster.partition} \
+-o {cluster.output}"


### PR DESCRIPTION
Patch to fix error that pops up for rule "gatk_Apply_BQSR". The snakemake wrapper requires you to specify the java memory allocation for this rule (specified by the user as with MAXMEMORY: in the config file) as G for gigabytes rather than g for gigabytes (eg. '40g' compared to '40G'). All other rules take this parameter as 'g'. In the broader interest of maintaining the flexibility of the pipeline - I'm slowly removing the snakemake wrappers (I'm finding them somewhat restrictive when more complex features are incorporated into the pipeline), so I went the route of simply removing the snakemake wrapper for the rule "gatk_Apply_BQSR"
